### PR TITLE
feat: add `force_push_bypassers` (maybe barebones)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,7 @@ resource "github_branch_protection" "branch_protection" {
 
   allows_deletions                = try(var.branch_protections_v4[each.value].allows_deletions, false)
   allows_force_pushes             = try(var.branch_protections_v4[each.value].allows_force_pushes, false)
+  force_push_bypassers            = try(var.branch_protections_v4[each.value].force_push_bypassers, [])
   blocks_creations                = try(var.branch_protections_v4[each.value].blocks_creations, false)
   enforce_admins                  = try(var.branch_protections_v4[each.value].enforce_admins, true)
   push_restrictions               = try(var.branch_protections_v4[each.value].push_restrictions, [])

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = ">= 5.27, < 6.0"
     }
   }
 }


### PR DESCRIPTION
We need this statement to allow our GitOps bot to force push. Otherwise, we'd have to write a ruleset for it... 

The Mineros module doesn't seem to be maintained and @kevcube has been making PR there that hasn't been noticed so... 

Since v5.27 of the GitHub provider (https://github.com/integrations/terraform-provider-github/releases/tag/v5.27.0) they allowed force_push_bypassers. I'm upgrading the minimum version, there shouldn't be any issues - I tested this with a plan and it's clean, there's no affected changes with this version so I'm just doing this barebones.