### PR TITLE
feat(github_repository): ignore etag changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ resource "github_repository" "repository" {
   lifecycle {
     ignore_changes = [
       auto_init,
+      etag,
       license_template,
       gitignore_template,
       template,

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,8 @@ locals {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
-# Create the repository
+# Manage repository
+# https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "github_repository" "repository" {


### PR DESCRIPTION
Changes:
- ignore the etag. I'm seeing etags when I run tofu plan, but the diffs do not reflect code changes

For example,
![CleanShot 2025-05-01 at 12 17 09@2x](https://github.com/user-attachments/assets/958863b8-55e1-4832-8bc6-8b3dc4d32f88)
